### PR TITLE
使PNG编码更快

### DIFF
--- a/encoders/pngbmp.go
+++ b/encoders/pngbmp.go
@@ -74,7 +74,7 @@ func (e *EncoderPNGBMP) Encode(data []byte) []byte {
 
 	//RGBA<->RGB?????
 	var pngbuf bytes.Buffer
-	png.Encode(&pngbuf, &RGB{Bytes: buf.Bytes(), Side: side})
+	(&png.Encoder{CompressionLevel: png.NoCompression}).Encode(&pngbuf, &RGB{Bytes: buf.Bytes(), Side: side})
 
 	defer buf.Reset()
 	defer pngbuf.Reset()


### PR DESCRIPTION
在我的电脑上，他从16M/s提升到了67M/s，变快了4倍
随机数据下，大小增长可忽略不计

另外我不是很确定启用压缩会不会对文件完整性造成影响
但是不压缩一定没有影响
